### PR TITLE
feat: Make logs easy to reason about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0 DRAFT
+
+* Make info logs easy to reason about (ref https://github.com/near/near-lake/issues/11)
+
+
 ## 0.1.0-rc.0
 
 A first try in releasing the alpha version of NEAR Lake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,6 +2711,7 @@ name = "near-lake"
 version = "0.1.0-rc.0"
 dependencies = [
  "actix",
+ "anyhow",
  "aws-config",
  "aws-endpoint",
  "aws-sdk-s3",
@@ -2718,6 +2719,7 @@ dependencies = [
  "clap",
  "futures",
  "itertools",
+ "near-client",
  "near-indexer",
  "near-indexer-primitives",
  "openssl-probe",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,6 +1909,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,7 +2191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
- "serde",
 ]
 
 [[package]]
@@ -2195,6 +2200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -2708,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "0.1.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -2718,6 +2724,7 @@ dependencies = [
  "aws-smithy-http",
  "clap",
  "futures",
+ "humantime",
  "itertools",
  "near-client",
  "near-indexer",
@@ -3317,7 +3324,7 @@ dependencies = [
  "paperclip-actix",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "semver 0.9.0",
  "serde",
  "serde_derive",
@@ -3338,7 +3345,7 @@ dependencies = [
  "once_cell",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "serde_json",
 ]
 
@@ -3351,7 +3358,7 @@ dependencies = [
  "mime",
  "once_cell",
  "paperclip-macros",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "pin-project",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "0.1.0-rc.0"
+version = "0.2.0-rc.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 actix = "=0.11.0-beta.2"
+anyhow = "1.0.51"
 aws-config = "0.6.0"
 aws-endpoint = "0.6.0"
 aws-sdk-s3 = "0.6.0"
@@ -25,3 +26,4 @@ tracing-subscriber = "0.2.4"
 
 near-indexer = { git = "https://github.com/near/nearcore", rev = "5f09a3bf042b32d1ff26554433ad6449199ea02a" }
 near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "5f09a3bf042b32d1ff26554433ad6449199ea02a" }
+near-client = { git = "https://github.com/near/nearcore", rev = "5f09a3bf042b32d1ff26554433ad6449199ea02a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ aws-sdk-s3 = "0.6.0"
 aws-smithy-http = "0.36.0"
 clap = { version = "3.0.0-beta.5", features = ["color", "derive", "env"] }
 futures = "0.3.5"
+humantime = "2.1.0"
 itertools = "^0.10.3"
 openssl-probe = { version = "0.1.2" }
 serde = { version = "1", features = ["derive"] }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,14 @@
+use near_indexer_primitives::types;
+
+/// Fetches the status to retrieve `latest_block_height` to determine if we need to fetch
+/// entire block or we already fetched this block.
+pub(crate) async fn fetch_latest_block(
+    client: &actix::Addr<near_client::ViewClientActor>,
+) -> anyhow::Result<u64> {
+    let block = client
+        .send(near_client::GetBlock(types::BlockReference::Finality(
+            types::Finality::Final,
+        )))
+        .await??;
+    Ok(block.header.height)
+}


### PR DESCRIPTION
Closes #11 

Logs will be printed every 10 seconds like in `nearcore`

Example:

```
INFO near_lake: # 2508 | Blocks processing: 0| Blocks done: 2509. Bps 250.90 b/s  | 0.00 s to catch up the tip

# 2508 - last processed block by near_lake
Blocks processing: 0 - number of blocks currently being processed
Blocks done: 2509 - total number of processed blocks
Bps 250.90 b/s - blocks per second (during last 10 sec)
0s to catch up the tip - seconds to catch up with the tip of the network
```

Originally in the issue @frol said

> List of the block heights that are processed (if there are too many of them [let's say 5], print 4 oldest ones and 1 the most recent)

But I don't think it'd be helpful to print a bunch of blocks height, I think the number of the currently in-progress blocks should be enough. However, we can change it later.