### PR TITLE
Add custom s3 endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,6 +2724,7 @@ dependencies = [
  "aws-smithy-http",
  "clap",
  "futures",
+ "http",
  "humantime",
  "itertools",
  "near-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ aws-sdk-s3 = "0.6.0"
 aws-smithy-http = "0.36.0"
 clap = { version = "3.0.0-beta.5", features = ["color", "derive", "env"] }
 futures = "0.3.5"
+http = "0.2"
 humantime = "2.1.0"
 itertools = "^0.10.3"
 openssl-probe = { version = "0.1.2" }

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Commands to run NEAR Lake, after `./target/release/near-lake`
 | `run`   	|                              	|                                                                  	| Runs the node                                                                                                                                                                                                                                                                                                                                                           	|
 |         	| `--bucket`                   	| Required                                                         	| AWS S3 Bucket name                                                                                                                                                                                                                                                                                                                                                      	|
 |         	| `--region`                   	| Required                                                         	| AWS S3 Bucket region                                                                                                                                                                                                                                                                                                                                                    	|
+|           | `--endpoint`                  | Optional                                                          | AWS S3 compatible API endpoint                                                                                                                                                                                                                                                                                                                                            |
 |         	| `--stream-while-syncing`     	| Optional                                                         	| If provided Indexer streams blocks while they appear on the node instead of waiting the node to be fully synced                                                                                                                                                                                                                                                         	|
 |         	| `--concurrency`              	| Default 1                                                        	| Defines the concurrency for the process of saving block data to AWS S3                                                                                                                                                                                                                                                                                                  	|
 |         	| `sync-from-latest`           	| One of the `sync-` subcommands is required                       	| Tells the node to start indexing from the latest block in the network                                                                                                                                                                                                                                                                                                   	|
@@ -163,6 +164,23 @@ We write all the data to AWS S3 buckets:
 
 - `near-lake-data-testnet` (`eu-central-1` region) for testnet
 - `near-lake-data-mainnet` (`eu-central-1` region) for mainnet
+
+## Custom S3 storage
+
+In case you want to run you own near-lake instance and store data in some S3 compatible storage ([Minio](https://min.io/) or [Localstack](https://localstack.cloud/) as example)
+You can owerride default S3 API endpoint by using `--endpoint` option
+
+- run minio
+
+```bash
+$ mkdir -p /data/near-lake-custom && minio server /data
+```
+
+- run near-lake
+
+```bash
+$ ./target/release/near-lake --home ~/.near/testnet run --endpoint http://127.0.0.1:9000 --bucket near-lake-custom sync-from-latest
+```
 
 ### Data structure
 

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -29,7 +29,7 @@ pub(crate) enum SubCommand {
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct RunArgs {
-    /// AWS API Endpoint
+    /// AWS S3 compatible API Endpoint
     #[clap(long)]
     pub endpoint: Option<String>,
     /// Name of S3 bucket

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -30,8 +30,8 @@ pub(crate) enum SubCommand {
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct RunArgs {
     /// AWS API Endpoint
-    #[clap(long, default_value = "")]
-    pub endpoint: String,
+    #[clap(long)]
+    pub endpoint: Option<String>,
     /// Name of S3 bucket
     #[clap(long)]
     pub bucket: String,

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -29,6 +29,9 @@ pub(crate) enum SubCommand {
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct RunArgs {
+    /// AWS API Endpoint
+    #[clap(long, default_value = "")]
+    pub endpoint: String,
     /// Name of S3 bucket
     #[clap(long)]
     pub bucket: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::{ByteStream, Client, Region, Endpoint};
-use http::Uri;
 use clap::Parser;
 use configs::{Opts, SubCommand};
 use futures::StreamExt;
+use http::Uri;
 use tokio::sync::Mutex;
 use tracing_subscriber::EnvFilter;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ async fn listen_blocks(
         let s3_endpoint = endpoint.parse::<Uri>().unwrap();
         s3_conf = s3_conf.endpoint_resolver(Endpoint::immutable(s3_endpoint));
     }
-    // let client = Client::new(&shared_config);
+
     let client = Client::from_conf(s3_conf.build());
 
     let mut handle_messages = tokio_stream::wrappers::ReceiverStream::new(stream)


### PR DESCRIPTION
For local development its nice to have ability for define custom s3 endpoint in order to point near-lake to some mock address or s3 compatible server (as example Localstack or Minio). I propose additional args to be added into config. In case its defined, near-lake should override S3 endpoint resolver, otherwise it uses default one (depended on aws region).