### PR TITLE
refactor: 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## 0.2.0 DRAFT
+## 0.1.0
 
 * Make info logs easy to reason about (ref https://github.com/near/near-lake/issues/11)
-
+* Optional `--endpoint` parameter to store the data to custom S3 compatible storage
 
 ## 0.1.0-rc.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "0.2.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "0.2.0-rc.1"
+version = "0.1.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # near-lake
 
-**NB! The project is in early stage of development and shouldn't be used in production environmental yet**
-
 NEAR Lake is an indexer built on top of [NEAR Indexer microframework](https://github.com/nearprotocol/nearcore/tree/master/chain/indexer)
 to watch the network and store all the events as JSON files on AWS S3.
 
@@ -208,3 +206,7 @@ All NEAR Lake AWS S3 buckets have [Request Payer](https://docs.aws.amazon.com/Am
 Once we [set up the public access to the buckets](https://github.com/near/near-lake/issues/22) anyone will be able to build their own code to read it through.
 
 For our own needs we are working on [NEAR Lake Framework](https://github.com/near/near-lake-framework) to have a simple way to create an indexer on top of the data stored by NEAR Lake itself.
+
+**See the [official announce of NEAR Lake Framework on the NEAR Gov Forum](https://gov.near.org/t/announcement-near-lake-framework-brand-new-word-in-indexer-building-approach/17668)**
+
+

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -51,12 +51,12 @@ pub(crate) struct RunArgs {
 
 impl RunArgs {
     pub(crate) fn to_indexer_config(
-        self,
+        &self,
         home_dir: std::path::PathBuf,
     ) -> near_indexer::IndexerConfig {
         near_indexer::IndexerConfig {
             home_dir,
-            sync_mode: self.sync_mode.into(),
+            sync_mode: self.sync_mode.clone().into(),
             await_for_node_synced: if self.stream_while_syncing {
                 near_indexer::AwaitForNodeSyncedEnum::StreamWhileSyncing
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{ByteStream, Client, Region, Endpoint};
+use aws_sdk_s3::{ByteStream, Client, Endpoint, Region};
 use clap::Parser;
 use configs::{Opts, SubCommand};
 use futures::StreamExt;
@@ -162,12 +162,9 @@ async fn listen_blocks(
     // Owerride S3 endpoint in case you want to use custom solution
     // like Minio or Localstack as a S3 compatible storage
     if let Some(s3_endpoint) = endpoint {
-        s3_conf = s3_conf.endpoint_resolver(Endpoint::immutable(s3_endpoint.parse::<Uri>().unwrap()));
-        tracing::info!(
-            target: INDEXER,
-            "Custom S3 endpoint used: {}",
-            s3_endpoint
-        );
+        s3_conf =
+            s3_conf.endpoint_resolver(Endpoint::immutable(s3_endpoint.parse::<Uri>().unwrap()));
+        tracing::info!(target: INDEXER, "Custom S3 endpoint used: {}", s3_endpoint);
     }
 
     let client = Client::from_conf(s3_conf.build());
@@ -238,19 +235,14 @@ async fn put_object_or_retry(
             Ok(_) => break,
             Err(err) => {
                 // We haven't found the way to check credentials before the request has been sent
-                // This is the weird yet working solution to fail entire application if we got
+                // This is the weird yet working solution to throw an error if we got
                 // missing credentials error
-                match err {
-                    aws_smithy_http::result::SdkError::ConstructionFailure(box_error) => {
-                        if box_error.to_string()
-                            == String::from("No credentials in the property bag")
-                        {
-                            tracing::error!(target: INDEXER, "No credentials in the property bag");
-                            std::process::abort();
-                        }
+                if let aws_smithy_http::result::SdkError::ConstructionFailure(box_error) = err {
+                    if box_error.to_string() == *"No credentials in the property bag".to_string() {
+                        tracing::error!(target: INDEXER, "No credentials in the property bag");
+                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                     }
-                    _ => {}
-                };
+                }
                 tracing::warn!(
                     target: INDEXER,
                     "Failed to put {} to S3, retrying",


### PR DESCRIPTION
I'd like to trigger the 0.1.0 release to be built. I guess we are ready

* Remove the recommendation from the README not to use the project because of the early stage
* Put the version 0.1.0
* Update the CHANGELOG
* `fmt`
* resolve `clippy` suggestions
* instance is not aborted on missing credentials anymore. Fixes #5 