### PR TITLE
ci: Fixed the release binary compatibility with data backup

### DIFF
--- a/cross/x86_64-unknown-linux-gnu/Dockerfile
+++ b/cross/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,14 @@
-FROM rustembedded/cross:x86_64-unknown-linux-gnu-0.2.1
+FROM ubuntu:18.04
 
-RUN apt-get update && \
-    apt-get install --assume-yes binutils-dev libudev-dev clang-8 llvm-8 gcc
+# Copy from nearcore:
+# https://github.com/near/nearcore/blob/master/Dockerfile
+RUN apt-get update -qq && \
+    apt-get install -y \
+        git \
+        cmake \
+        g++ \
+        pkg-config \
+        libssl-dev \
+        curl \
+        llvm \
+        clang


### PR DESCRIPTION
*Resolves #37*

Somehow when I build the binary with ubuntu:16.04, the binary cannot read the data backups on mainnet/testnet while it works fine with localnet (even if initiated by the binary built with ubuntu:18.04), so ultimately, I decided to just go with the same environment (ubuntu:18.04) as we use for nearcore Dockerfile.