### PR TITLE
chore: Upgrade nearcore to 1.27.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6
+
+* Upgrade `nearcore` to 1.27.0-rc.4
+
 ## 0.1.5
 
 * Upgrade `nearcore` to 1.27.0-rc.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "itoa",
  "log",
  "mime",
+ "openssl",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
@@ -1431,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "delay-detector"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "cpu-time",
  "tracing",
@@ -2501,7 +2502,7 @@ dependencies = [
 [[package]]
 name = "near-account-id"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "borsh",
  "serde",
@@ -2510,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "near-cache"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "lru",
 ]
@@ -2518,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "borsh",
@@ -2546,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2564,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -2576,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "borsh",
@@ -2602,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -2611,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2653,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "chrono",
@@ -2670,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "arrayref",
  "blake2",
@@ -2696,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "borsh",
  "near-cache",
@@ -2717,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "anyhow",
@@ -2740,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "near-primitives",
  "serde",
@@ -2750,7 +2751,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2780,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix-http",
  "awc",
@@ -2795,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "near-chain-configs",
@@ -2816,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "actix",
  "anyhow",
@@ -2844,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "near-logger-utils"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "near-o11y",
  "tracing",
@@ -2853,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "prometheus",
  "tracing",
@@ -2862,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "anyhow",
@@ -2904,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "near-network-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "anyhow",
@@ -2920,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "near-o11y"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "atty",
  "backtrace",
@@ -2940,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "bitflags",
@@ -2957,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "quote",
  "syn",
@@ -2966,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -2979,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "borsh",
  "byteorder",
@@ -3007,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "base64 0.11.0",
  "borsh",
@@ -3023,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "near-rate-limiter"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "bytes",
@@ -3037,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "near-rosetta-rpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3065,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "quote",
  "serde",
@@ -3075,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "near-rpc-error-core",
  "serde",
@@ -3085,12 +3086,12 @@ dependencies = [
 [[package]]
 name = "near-stable-hasher"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "borsh",
  "byteorder",
@@ -3119,14 +3120,16 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "actix-web",
  "awc",
  "futures",
+ "near-metrics",
  "near-performance-metrics",
  "near-performance-metrics-macros",
+ "once_cell",
  "openssl",
  "serde",
  "serde_json",
@@ -3136,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "borsh",
  "near-account-id",
@@ -3147,7 +3150,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -3167,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3200,7 +3203,7 @@ dependencies = [
 [[package]]
 name = "nearcore"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3271,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca#dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca"
+source = "git+https://github.com/near/nearcore?rev=d0f40ac8addc691e134d202736d15eea0fbc1f2a#d0f40ac8addc691e134d202736d15eea0fbc1f2a"
 dependencies = [
  "borsh",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.60.0"
@@ -17,7 +17,7 @@ futures = "0.3.5"
 http = "0.2"
 humantime = "2.1.0"
 itertools = "0.10.0"
-openssl-probe = { version = "0.1.2" }
+openssl-probe = "0.1.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["sync", "time"] }
@@ -25,6 +25,6 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.34"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca" }
-near-client = { git = "https://github.com/near/nearcore", rev = "dfabc4cd90f4fa3bb435af4f3c95da0d34ec5fca" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "d0f40ac8addc691e134d202736d15eea0fbc1f2a" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "d0f40ac8addc691e134d202736d15eea0fbc1f2a" }
+near-client = { git = "https://github.com/near/nearcore", rev = "d0f40ac8addc691e134d202736d15eea0fbc1f2a" }


### PR DESCRIPTION
Bump version `0.1.6`